### PR TITLE
Feature/text on a knob

### DIFF
--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -192,7 +192,16 @@ import QuartzCore
     *	Sets the text on a knob.
     *   The size of the knob changes depending on the text size.
     */
-    public var textLabel: UILabel!
+    public var textLabel: UILabel! {
+        willSet {
+            newValue.sizeToFit()
+            knobSize.width = newValue.frame.size.width + self.frame.height - 2
+        }
+        didSet {
+            textLabel.center = thumbImageView.center
+            thumbImageView.addSubview(textLabel)
+        }
+    }
     
     // internal
     internal var backgroundView: UIView!

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -232,7 +232,7 @@ import QuartzCore
     *   Initialization
     */
     public convenience init() {
-        self.init(frame: CGRectMake(0, 0, 50, 31))
+        self.init(frame: CGRectMake(0, 0, 51, 31))
     }
     
     required public init(coder aDecoder: NSCoder) {
@@ -242,7 +242,7 @@ import QuartzCore
     }
     
     override public init(frame: CGRect) {
-        let initialFrame = CGRectIsEmpty(frame) ? CGRectMake(0, 0, 50, 31) : frame
+        let initialFrame = CGRectIsEmpty(frame) ? CGRectMake(0, 0, 51, 31) : frame
         super.init(frame: initialFrame)
         
         self.setup()
@@ -288,9 +288,9 @@ import QuartzCore
         offLabel.font = UIFont.systemFontOfSize(12)
         backgroundView.addSubview(offLabel)
 
-        self.textLabel = UILabel()
-        textLabel.textColor = UIColor.grayColor()
-        textLabel.font = UIFont.systemFontOfSize(12)
+        textLabel = UILabel()
+        textLabel.textColor = .grayColor()
+        textLabel.font = .systemFontOfSize(12)
         
         // thumb
         self.thumbView = UIView(frame: CGRectMake(1, 1, knobSize.width, knobSize.height))

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -209,7 +209,8 @@ import QuartzCore
     private var switchValue: Bool = false
     lazy var knobSize: CGSize = {
         let height = self.frame.height - 2
-        let size = CGSize (width: height, height: height)
+        let width = self.frame.height + 20
+        let size = CGSize (width: width, height: height)
         return size
     } ()
     
@@ -392,12 +393,12 @@ import QuartzCore
             self.offLabel.frame = CGRectMake(frame.size.height, 0, frame.size.width - frame.size.height, frame.size.height)
             
             // thumb
-            let normalKnobWidth = frame.size.height - 2
+            let normalKnobWidth = knobSize.width
             if self.on {
-                thumbView.frame = CGRectMake(frame.size.width - (normalKnobWidth + 1), 1, frame.size.height - 2, normalKnobWidth)
+                thumbView.frame = CGRectMake(frame.size.width - (normalKnobWidth + 1), 1, normalKnobWidth, knobSize.height)
             }
             else {
-                thumbView.frame = CGRectMake(1, 1, normalKnobWidth, normalKnobWidth)
+                thumbView.frame = CGRectMake(1, 1, normalKnobWidth, knobSize.height)
             }
             
             thumbView.layer.cornerRadius = self.isRounded ? (frame.size.height * 0.5) - 1 : 2

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -25,6 +25,8 @@
 import UIKit
 import QuartzCore
 
+let uiswitchFrame = CGRect(x: 0, y: 0, width: 51, height: 31)
+
 @IBDesignable @objc public class SevenSwitch: UIControl {
     
     // public
@@ -232,7 +234,7 @@ import QuartzCore
     *   Initialization
     */
     public convenience init() {
-        self.init(frame: CGRectMake(0, 0, 51, 31))
+        self.init(frame: uiswitchFrame)
     }
     
     required public init(coder aDecoder: NSCoder) {
@@ -242,7 +244,7 @@ import QuartzCore
     }
     
     override public init(frame: CGRect) {
-        let initialFrame = CGRectIsEmpty(frame) ? CGRectMake(0, 0, 51, 31) : frame
+        let initialFrame = CGRectIsEmpty(frame) ? uiswitchFrame : frame
         super.init(frame: initialFrame)
         
         self.setup()

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -196,9 +196,10 @@ import QuartzCore
         willSet {
             newValue.sizeToFit()
             knobSize.width = newValue.frame.size.width + self.frame.height - 2
+            layoutSubviews()
         }
         didSet {
-            textLabel.center = thumbImageView.center
+            textLabel.center = thumbView.center
             thumbImageView.addSubview(textLabel)
         }
     }
@@ -218,7 +219,7 @@ import QuartzCore
     private var switchValue: Bool = false
     lazy var knobSize: CGSize = {
         let height = self.frame.height - 2
-        let width = self.frame.height + 20
+        let width = self.frame.height - 2
         let size = CGSize (width: width, height: height)
         return size
     } ()

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -207,7 +207,11 @@ import QuartzCore
     private var isAnimating: Bool = false
     private var userDidSpecifyOnThumbTintColor: Bool = false
     private var switchValue: Bool = false
-    private var knobSize: CGSize = CGSize(width: 31, height: 31)
+    lazy var knobSize: CGSize = {
+        let height = self.frame.height - 2
+        let size = CGSize (width: height, height: height)
+        return size
+    } ()
     
     /*
     *   Initialization
@@ -270,7 +274,7 @@ import QuartzCore
         backgroundView.addSubview(offLabel)
         
         // thumb
-        self.thumbView = UIView(frame: CGRectMake(1, 1, self.frame.size.height - 2, self.frame.size.height - 2))
+        self.thumbView = UIView(frame: CGRectMake(1, 1, knobSize.width, knobSize.height))
         thumbView.backgroundColor = self.thumbTintColor
         thumbView.layer.cornerRadius = (self.frame.size.height * 0.5) - 1
         thumbView.layer.shadowColor = self.shadowColor.CGColor

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -301,7 +301,7 @@ import QuartzCore
         startTrackingValue = self.on
         didChangeWhileTracking = false
         
-        let activeKnobWidth = self.bounds.size.height - 2 + 5
+        let activeKnobWidth = knobSize.width + 5
         isAnimating = true
         
         UIView.animateWithDuration(0.3, delay: 0.0, options: UIViewAnimationOptions.CurveEaseOut | UIViewAnimationOptions.BeginFromCurrentState, animations: {
@@ -432,7 +432,7 @@ import QuartzCore
     *   optionally make it animated
     */
     private func showOn(animated: Bool) {
-        let normalKnobWidth = self.bounds.size.height - 2
+        let normalKnobWidth = knobSize.width
         let activeKnobWidth = normalKnobWidth + 5
         if animated {
             isAnimating = true
@@ -480,7 +480,7 @@ import QuartzCore
     *   optionally make it animated
     */
     private func showOff(animated: Bool) {
-        let normalKnobWidth = self.bounds.size.height - 2
+        let normalKnobWidth = knobSize.width
         let activeKnobWidth = normalKnobWidth + 5
         
         if animated {

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -188,6 +188,12 @@ import QuartzCore
     */
     public var offLabel: UILabel!
     
+    /*
+    *	Sets the text on a knob.
+    *   The size of the knob changes depending on the text size.
+    */
+    public var textLabel: UILabel!
+    
     // internal
     internal var backgroundView: UIView!
     internal var thumbView: UIView!
@@ -201,6 +207,7 @@ import QuartzCore
     private var isAnimating: Bool = false
     private var userDidSpecifyOnThumbTintColor: Bool = false
     private var switchValue: Bool = false
+    private var knobSize: CGSize = CGSize(width: 31, height: 31)
     
     /*
     *   Initialization

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -213,7 +213,7 @@ import QuartzCore
     *   Initialization
     */
     public convenience init() {
-        self.init(frame: CGRectMake(0, 0, 50, 30))
+        self.init(frame: CGRectMake(0, 0, 50, 31))
     }
     
     required public init(coder aDecoder: NSCoder) {
@@ -223,7 +223,7 @@ import QuartzCore
     }
     
     override public init(frame: CGRect) {
-        let initialFrame = CGRectIsEmpty(frame) ? CGRectMake(0, 0, 50, 30) : frame
+        let initialFrame = CGRectIsEmpty(frame) ? CGRectMake(0, 0, 50, 31) : frame
         super.init(frame: initialFrame)
         
         self.setup()

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -424,6 +424,7 @@ let uiswitchFrame = CGRect(x: 0, y: 0, width: 51, height: 31)
             }
             
             thumbView.layer.cornerRadius = self.isRounded ? (frame.size.height * 0.5) - 1 : 2
+            thumbView.layer.shadowPath = UIBezierPath(roundedRect: thumbView.bounds, cornerRadius: thumbView.layer.cornerRadius).CGPath
         }
     }
     

--- a/SevenSwitch.swift
+++ b/SevenSwitch.swift
@@ -189,21 +189,25 @@ import QuartzCore
     public var offLabel: UILabel!
     
     /*
-    *	Sets the text on a knob.
+    *	For customizations only. Text should be set to knobTest
     *   The size of the knob changes depending on the text size.
     */
-    public var textLabel: UILabel! {
-        willSet {
-            newValue.sizeToFit()
-            knobSize.width = newValue.frame.size.width + self.frame.height - 2
-            layoutSubviews()
-        }
+    public var textLabel: UILabel!
+    
+    /*
+    *	Set text which appears on top of the knob
+    *   The size of the knob changes depending on the text size.
+    */
+    public var knobText: String! {
         didSet {
-            textLabel.center = thumbView.center
-            thumbImageView.addSubview(textLabel)
+            textLabel.text = knobText
+            textLabel.sizeToFit()
+            knobSize.width = textLabel.frame.size.width + self.frame.height - 2
+            layoutSubviews()
+            textLabel.center = thumbImageView.center
         }
     }
-    
+
     // internal
     internal var backgroundView: UIView!
     internal var thumbView: UIView!
@@ -283,6 +287,10 @@ import QuartzCore
         offLabel.textColor = UIColor.lightGrayColor()
         offLabel.font = UIFont.systemFontOfSize(12)
         backgroundView.addSubview(offLabel)
+
+        self.textLabel = UILabel()
+        textLabel.textColor = UIColor.grayColor()
+        textLabel.font = UIFont.systemFontOfSize(12)
         
         // thumb
         self.thumbView = UIView(frame: CGRectMake(1, 1, knobSize.width, knobSize.height))
@@ -302,7 +310,9 @@ import QuartzCore
         thumbImageView.contentMode = UIViewContentMode.Center
         thumbImageView.autoresizingMask = UIViewAutoresizing.FlexibleWidth
         thumbView.addSubview(thumbImageView)
-    
+        
+        thumbImageView.addSubview(textLabel)
+
         self.on = false
     }
     

--- a/SevenSwitchExample/SevenSwitchExample.xcodeproj/project.pbxproj
+++ b/SevenSwitchExample/SevenSwitchExample.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		45B6529C176E3A440006F201 /* check@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "check@2x.png"; sourceTree = "<group>"; };
 		45B6529D176E3A440006F201 /* cross.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cross.png; sourceTree = "<group>"; };
 		45B6529E176E3A440006F201 /* cross@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "cross@2x.png"; sourceTree = "<group>"; };
-		45DD2ABD1954C14B0028A5DB /* SevenSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SevenSwitch.swift; path = ../../SevenSwitch.swift; sourceTree = "<group>"; };
+		45DD2ABD1954C14B0028A5DB /* SevenSwitch.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; name = SevenSwitch.swift; path = ../../SevenSwitch.swift; sourceTree = "<group>"; };
 		45F7C62E176D202700AE1301 /* SevenSwitchExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SevenSwitchExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		45F7C631176D202700AE1301 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		45F7C633176D202700AE1301 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };

--- a/SevenSwitchExample/SevenSwitchExample/ViewController.swift
+++ b/SevenSwitchExample/SevenSwitchExample/ViewController.swift
@@ -16,6 +16,11 @@ class ViewController: UIViewController {
         
         ibSwitch.onTintColor = UIColor(red: 0.20, green: 0.42, blue: 0.86, alpha: 1)
         ibSwitch.on = true
+      
+      let label = UILabel()
+      label.text = "chk "
+      
+      //ibSwitch.textLabel = label
         
         // this will create the switch with default dimensions, you'll still need to set the position though
         // you also have the option to pass in a frame of any size you choose


### PR DESCRIPTION
So, I forked the library and added custom text on the knob functionality to it.
How to use: 
Create the switch
set the text by: mySwitch.knobText = "HyperText"

The knob will adjust its width automatically.
Note: switch width has to be bigger than the width of the knob. (pay attention to the size of the text you set to it)

@vadymmarkov, @zenangst any thoughts on this?
